### PR TITLE
Fix GitHub links (#5835)

### DIFF
--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -59,4 +59,4 @@ Betamax
 `Betamax`_ records your HTTP interactions so the NSA does not have to.
 A VCR imitation designed only for Python-Requests.
 
-.. _betamax: https://github.com/sigmavirus24/betamax
+.. _betamax: https://github.com/betamaxpy/betamax

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1006,7 +1006,7 @@ library to use SSLv3::
                 block=block, ssl_version=ssl.PROTOCOL_SSLv3)
 
 .. _`described here`: https://www.kennethreitz.org/essays/the-future-of-python-http
-.. _`urllib3`: https://github.com/shazow/urllib3
+.. _`urllib3`: https://github.com/urllib3/urllib3
 
 .. _blocking-or-nonblocking:
 
@@ -1025,7 +1025,7 @@ out there that combine Requests with one of Python's asynchronicity frameworks.
 Some excellent examples are `requests-threads`_, `grequests`_, `requests-futures`_, and `httpx`_.
 
 .. _`requests-threads`: https://github.com/requests/requests-threads
-.. _`grequests`: https://github.com/kennethreitz/grequests
+.. _`grequests`: https://github.com/spyoungtech/grequests
 .. _`requests-futures`: https://github.com/ross/requests-futures
 .. _`httpx`: https://github.com/encode/httpx
 


### PR DESCRIPTION
All of these links now redirect to a repo under a different GitHub
user account.